### PR TITLE
Merge

### DIFF
--- a/notebooks/3_Test_Models.ipynb
+++ b/notebooks/3_Test_Models.ipynb
@@ -96,7 +96,7 @@
     "        ParticleType.GAMMA_POINT\n",
     "    ],  # Add as much as you want, must provide a directory for each\n",
     "    config_dir=\"/path/to/your/configs/\",  # Where the .sh scripts, configs and logs will be stored\n",
-    "    batch_size=512,\n",
+    "    batch_size=64,\n",
     "    # Other options are available\n",
     ")"
    ]

--- a/notebooks/5_Make_IRFs.ipynb
+++ b/notebooks/5_Make_IRFs.ipynb
@@ -74,13 +74,14 @@
     "zenith, azimuth = 10 * u.deg, 180 * u.deg\n",
     "\n",
     "# ⚠️⚠️⚠️ Make sure output files are unique !!!\n",
-    "config = \"/path/to/your/public-conf.yml\"  # Example config found in ressources, do not modify or move it after producing IRFs\n",
+    "details = \"_eff70\" # To make sure every file has a unique name based on the cuts implemented.\n",
+    "config = f\"/path/to/your/public-conf{details}.yml\"  # Example config found in ressources, do not modify or move it after producing IRFs\n",
     "output_cuts_file = (\n",
-    "    f\"/path/to/your/IRFs/cuts_{zenith.value:.2f}_{azimuth.value:.2f}.fits\"\n",
+    "    f\"/path/to/your/IRFs/cuts_{zenith.value:.2f}_{azimuth.value:.2f}{details}.fits\"\n",
     ")\n",
-    "output_irf_file = f\"/path/to/your/IRFs/IRFs_{zenith.value:.2f}_{azimuth.value:.2f}.fits\"\n",
+    "output_irf_file = f\"/path/to/your/IRFs/IRFs_{zenith.value:.2f}_{azimuth.value:.2f}{details}.fits\"\n",
     "output_benchmark_file = (\n",
-    "    f\"/path/to/your/IRFs/benchmark_{zenith.value:.2f}_{azimuth.value:.2f}.fits\"\n",
+    "    f\"/path/to/your/IRFs/benchmark_{zenith.value:.2f}_{azimuth.value:.2f}{details}.fits\"\n",
     ")"
    ]
   },

--- a/notebooks/6_Check_DL2.ipynb
+++ b/notebooks/6_Check_DL2.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/update_model_index.ipynb
+++ b/notebooks/update_model_index.ipynb
@@ -1,0 +1,162 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6da0c61",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import astropy.units as u\n",
+    "\n",
+    "from ctlearn_manager.io.io import load_model_from_index\n",
+    "from ctlearn_manager.tri_model import CTLearnTriModelManager\n",
+    "from ctlearn_manager.utils import ParticleType, remove_table_from_h5\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "647e6c77",
+   "metadata": {},
+   "source": [
+    "1. Delete the MC/DL2 table\n",
+    "2. Launch testing with overwrite set to False, so that only the MC/DL2 table is recreated with the desired files\n",
+    "3. Merge these files, even if there is one per pointing direction."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6abd6c87",
+   "metadata": {},
+   "source": [
+    "# 1. Delete tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da6b9187",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MODEL_INDEX_FILE = \"path\"\n",
+    "model_nickname = \"model_nickname\"\n",
+    "particle_type = ParticleType.GAMMA_POINT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7185ea20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "remove_table_from_h5(MODEL_INDEX_FILE, f\"/{model_nickname}/DL2/MC/{particle_type.value}\")\n",
+    "remove_table_from_h5(MODEL_INDEX_FILE, f\"/{model_nickname}/DL2/MC/{particle_type.value}.__table_column_meta__\") # removing metadata is mandatory"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4bf484e8",
+   "metadata": {},
+   "source": [
+    "# 2. Recreate DL2 Tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e492ec25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MODEL_INDEX_FILE = \"/path/to/your/ctlearn_models_index.h5\"\n",
+    "energy_model = load_model_from_index(\"energy_model_nickname\", MODEL_INDEX_FILE)\n",
+    "direction_model = load_model_from_index(\"direction_model\", MODEL_INDEX_FILE)\n",
+    "type_model = load_model_from_index(\"type_model\", MODEL_INDEX_FILE)\n",
+    "Tri_Model = CTLearnTriModelManager(\n",
+    "    direction_model=direction_model, energy_model=energy_model, type_model=type_model\n",
+    ")\n",
+    "Tri_Model.get_available_testing_directions()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90f28e21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copy here the direction you want to update in the manager\n",
+    "# ⚠️ Make sure the output files already exist (the ones tat were in the tables you deleted above).\n",
+    "zenith, azimuth = 32.059 * u.deg, 248.099 * u.deg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a2da82b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Tri_Model.launch_testing(\n",
+    "    zenith,\n",
+    "    azimuth,\n",
+    "    output_dirs=[\"/path/to/your/Testing_models/gamma_point/\"],\n",
+    "    launch_particle_types=[\n",
+    "        ParticleType.GAMMA_POINT\n",
+    "    ],  # Add as much as you want, must provide a directory for each\n",
+    "    config_dir=\"/path/to/your/configs/\",  # Where the .sh scripts, configs and logs will be stored\n",
+    "    batch_size=64,\n",
+    "    overwrite=False\n",
+    "    # Other options are available\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6510b6aa",
+   "metadata": {},
+   "source": [
+    "# 3. Merge (mandatory)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bc2ab7a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Tri_Model.merge_DL2_files(\n",
+    "    zenith,\n",
+    "    azimuth,\n",
+    "    output_file=\"/path/to/your/merged/gamma_point_50_300E3GeV_20_20deg.h5\", # If there is only one file, this output file is not written.\n",
+    "    particle_type=ParticleType.GAMMA_POINT,\n",
+    "    overwrite=True,\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "ctlearn",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/ctlearn_manager/model_manager.py
+++ b/src/ctlearn_manager/model_manager.py
@@ -770,9 +770,9 @@ class CTLearnModelManager:
             overwrite=True,
             serialize_meta=True,
         )
-        print(
-            f"Testing {particle_type.value} at ({testing_zenith_distance}, {testing_azimuth}) deg : {testing_dir}/{testing_pattern} updated"
-        )
+        # print(
+        #     f"Testing {particle_type.value} at ({testing_zenith_distance}, {testing_azimuth}) : {testing_dir}/{testing_pattern} updated"
+        # )
 
     def update_model_manager_DL2_MC_file(
         self, testing_MC_DL2_file: str, testing_MC_DL2_data_sample: DataSample
@@ -835,7 +835,7 @@ class CTLearnModelManager:
                 == testing_azimuth
             )
             & (
-                DL2_gamma_table["merged"] is False
+                DL2_gamma_table["merged"] == False
             )
         )[0]
         if len(match) == 0:
@@ -1012,7 +1012,7 @@ class CTLearnModelManager:
 
         dl2_mc_index_table = IndexTables(self, particle_type).DL2_MC
 
-        print(f"💾 Model {self.model_nickname} DL2 merged data update:")
+        # print(f"💾 Model {self.model_nickname} DL2 merged data update:")
         DL2_table = read_table_hdf5(
             self.model_index_file,
             path=dl2_mc_index_table.table_path,
@@ -1027,11 +1027,25 @@ class CTLearnModelManager:
                 == testing_DL2_azimuth
             )
             & (
-                DL2_table["merged"] is False
+                DL2_table["merged"] == False  # noqa: E712
             )
         )[0]
         if len(match) > 0:
-            # DL2_table.remove_rows(match)
+            match = np.where(
+                (
+                    DL2_table[f"testing_DL2_{particle_type.value}_zenith_distances"]
+                    == testing_DL2_zenith_distance
+                )
+                & (
+                    DL2_table[f"testing_DL2_{particle_type.value}_azimuths"]
+                    == testing_DL2_azimuth
+                )
+                & (
+                    DL2_table["merged"] == True  # noqa: E712
+                )
+            )[0]
+            if len(match) > 0:
+                DL2_table.remove_rows(match)
             DL2_table.add_row(
                 [testing_DL2_merged_file, testing_DL2_zenith_distance, testing_DL2_azimuth, True]
             )
@@ -1043,7 +1057,7 @@ class CTLearnModelManager:
                 overwrite=True,
                 serialize_meta=True,
             )
-            print(f"\t➡️ Testing DL2 {particle_type.value} merged data updated")
+            # print(f"\t➡️ Testing DL2 {particle_type.value} merged data updated")
         else:
             raise ValueError(
                 f"DL2 table for {particle_type.value} does not exist for zenith distance {testing_DL2_zenith_distance} and azimuth {testing_DL2_azimuth}"
@@ -1409,7 +1423,7 @@ class CTLearnModelManager:
                                 DL2_table[f"testing_DL2_{particle_type.value}_azimuths"]
                                 == azimuth
                             )
-                            & (DL2_table["merged"] is True)
+                            & (DL2_table["merged"] == True)  # noqa: E712
                         )[0]
                     else:
                         match = np.where(
@@ -1421,7 +1435,7 @@ class CTLearnModelManager:
                                 DL2_table[f"testing_DL2_{particle_type.value}_azimuths"]
                                 == azimuth
                             )
-                            & (DL2_table["merged"] is False)
+                            & (DL2_table["merged"] == False)  # noqa: E712
                         )[0]
                 else:
                     match = np.where(
@@ -1843,7 +1857,7 @@ class ModelRangeOfValidity:
 
         training_gamma_table = read_table_hdf5(
             model_manager.model_index_file,
-            path=IndexTables(self, ParticleType.GAMMA_DIFFUSE).TRAINING.table_path,
+            path=IndexTables(model_manager, ParticleType.GAMMA_DIFFUSE).TRAINING.table_path,
         )
         # training_proton_table = read_table_hdf5(model_manager.model_index_file, path=f'{model_manager.model_nickname}/training/proton')
 
@@ -1935,7 +1949,7 @@ class ModelRangeOfValidity:
 
 class IndexTables:
 
-    def __call__(self, model_manager: CTLearnModelManager, particle_type: ParticleType=None):
+    def __init__(self, model_manager: CTLearnModelManager, particle_type: ParticleType=None):
         self.model_manager = model_manager
         self.particle_type = particle_type
 

--- a/src/ctlearn_manager/model_manager.py
+++ b/src/ctlearn_manager/model_manager.py
@@ -833,6 +833,9 @@ class CTLearnModelManager:
                 DL2_gamma_table[f"testing_DL2_{particle_type.value}_azimuths"]
                 == testing_azimuth
             )
+            & (
+                DL2_gamma_table["merged"] is False
+            )
         )[0]
         if len(match) == 0:
             assert testing_zenith_distance.unit == u.deg, (
@@ -842,7 +845,7 @@ class CTLearnModelManager:
                 f"Azimuth must be in degrees: {testing_azimuth}"
             )
             DL2_gamma_table.add_row(
-                [testing_MC_DL2_file, testing_zenith_distance, testing_azimuth]
+                [testing_MC_DL2_file, testing_zenith_distance, testing_azimuth, False]
             )
         write_table_hdf5(
             DL2_gamma_table,
@@ -1022,11 +1025,14 @@ class CTLearnModelManager:
                 DL2_table[f"testing_DL2_{particle_type.value}_azimuths"]
                 == testing_DL2_azimuth
             )
+            & (
+                DL2_table["merged"] is False
+            )
         )[0]
         if len(match) > 0:
-            DL2_table.remove_rows(match)
+            # DL2_table.remove_rows(match)
             DL2_table.add_row(
-                [testing_DL2_merged_file, testing_DL2_zenith_distance, testing_DL2_azimuth]
+                [testing_DL2_merged_file, testing_DL2_zenith_distance, testing_DL2_azimuth, True]
             )
             write_table_hdf5(
                 DL2_table,
@@ -1329,6 +1335,7 @@ class CTLearnModelManager:
         self,
         zenith: float,
         azimuth: float,
+        merged: bool = None,
         particle_types: list[ParticleType] = [
             ParticleType.GAMMA_POINT,
             ParticleType.PROTON,
@@ -1378,7 +1385,45 @@ class CTLearnModelManager:
                     self.model_index_file,
                     path=dl2_mc_index_table.table_path,
                 )
-                match = np.where(
+
+                if merged is None:
+                    pre_match = np.where(
+                        (
+                            DL2_table[f"testing_DL2_{particle_type.value}_zenith_distances"]
+                            == zenith
+                        )
+                        & (
+                            DL2_table[f"testing_DL2_{particle_type.value}_azimuths"]
+                            == azimuth
+                        )
+                    )[0]
+                    merged_states = DL2_table["merged"][pre_match]
+                    if True in merged_states:
+                        match = np.where(
+                            (
+                                DL2_table[f"testing_DL2_{particle_type.value}_zenith_distances"]
+                                == zenith
+                            )
+                            & (
+                                DL2_table[f"testing_DL2_{particle_type.value}_azimuths"]
+                                == azimuth
+                            )
+                            & (DL2_table["merged"] is True)
+                        )[0]
+                    else:
+                        match = np.where(
+                            (
+                                DL2_table[f"testing_DL2_{particle_type.value}_zenith_distances"]
+                                == zenith
+                            )
+                            & (
+                                DL2_table[f"testing_DL2_{particle_type.value}_azimuths"]
+                                == azimuth
+                            )
+                            & (DL2_table["merged"] is False)
+                        )[0]
+                else:
+                    match = np.where(
                     (
                         DL2_table[f"testing_DL2_{particle_type.value}_zenith_distances"]
                         == zenith
@@ -1387,6 +1432,7 @@ class CTLearnModelManager:
                         DL2_table[f"testing_DL2_{particle_type.value}_azimuths"]
                         == azimuth
                     )
+                    & (DL2_table["merged"] == merged)
                 )[0]
                 if len(match) == 0:
                     raise IndexError(

--- a/src/ctlearn_manager/model_manager.py
+++ b/src/ctlearn_manager/model_manager.py
@@ -11,7 +11,7 @@ import astropy.units as u
 import numpy as np
 from astropy.table import QTable
 
-from ctlearn_manager.utils.utils import (
+from ctlearn_manager.utils import (
     ClusterConfiguration,
     CTLearnManagerStyle,
     Cuts,
@@ -21,6 +21,7 @@ from ctlearn_manager.utils.utils import (
     get_irf_type_from_config,
     remove_row_from_table_utils,
     set_mpl_style,
+    IndexTables,
 )
 
 __all__ = [
@@ -133,8 +134,9 @@ class CTLearnModelManager:
         if not load:
             self.save_to_index(model_parameters)
             print(f"🧠 Model name: {self.model_nickname}")
+
         self.model_parameters_table = read_table_hdf5(
-            f"{self.model_index_file}", path=f"{self.model_nickname}/parameters"
+            f"{self.model_index_file}", path=IndexTables(self).PARAMETERS.table_path
         )
         self.validity = ModelRangeOfValidity(self)
         self.telescope_ids = ast.literal_eval(
@@ -152,13 +154,13 @@ class CTLearnModelManager:
         ]  # True if self.min_telescopes >= 2 else False
         training_table_gamma = read_table_hdf5(
             f"{self.model_index_file}",
-            path=f"{self.model_nickname}/training/gamma_diffuse",
+            path=IndexTables(self, ParticleType.GAMMA_DIFFUSE).TRAINING.table_path,
         )
 
         if self.model_parameters_table["reco"][0] == "type":
             training_table_proton = read_table_hdf5(
                 f"{self.model_index_file}",
-                path=f"{self.model_nickname}/training/proton",
+                path=IndexTables(self, ParticleType.PROTON).TRAINING.table_path,
             )
             if (len(training_table_proton["training_proton_patterns"]) == 0) or (
                 len(training_table_gamma["training_gamma_diffuse_patterns"]) == 0
@@ -251,40 +253,18 @@ class CTLearnModelManager:
         """
         from astropy.io.misc.hdf5 import read_table_hdf5, write_table_hdf5
 
+        paramaters_index_table = IndexTables(self).PARAMETERS
+
         try:
             model_table = QTable.read(
                 self.model_index_file,
                 format="hdf5",
-                path=f"{self.model_nickname}/parameters",
+                path=paramaters_index_table.table_path,
             )
             print(f"❌ Model nickname {self.model_nickname} already in table")
         except:
-            model_table = QTable(
-                names=[
-                    "model_nickname",
-                    "model_dir",
-                    "reco",
-                    "channels",
-                    "telescope_names",
-                    "telescope_ids",
-                    "notes",
-                    "max_training_epochs",
-                    "min_telescopes",
-                    "stereo",
-                ],
-                dtype=[
-                    "S256",
-                    "S256",
-                    "S256",
-                    "S256",
-                    "S256",
-                    "S256",
-                    "S256",
-                    int,
-                    int,
-                    bool,
-                ],
-            )
+            model_table = paramaters_index_table.default_table
+
             notes = model_parameters.get("notes", "")
             if not Path(model_parameters.get("model_dir", "")).is_absolute():
                 raise ValueError("The 'model_dir' must be an absolute path.")
@@ -336,7 +316,7 @@ class CTLearnModelManager:
             write_table_hdf5(
                 model_table,
                 self.model_index_file,
-                path=f"{self.model_nickname}/parameters",
+                path=paramaters_index_table.table_path,
                 append=True,
                 overwrite=True,
             )
@@ -346,35 +326,15 @@ class CTLearnModelManager:
             for training_sample in training_samples:
                 particle_type = training_sample.particle_type
 
+                training_index_table = IndexTables(self, particle_type).TRAINING
+
                 try:
                     training_table = read_table_hdf5(
                         self.model_index_file,
-                        path=f"{self.model_nickname}/training/{particle_type.value}",
+                        path=training_index_table.table_path,
                     )
                 except:
-                    training_table = QTable(
-                        names=[
-                            f"training_{particle_type.value}_dir",
-                            f"training_{particle_type.value}_patterns",
-                            f"training_{particle_type.value}_zenith_distances",
-                            f"training_{particle_type.value}_azimuths",
-                            f"training_{particle_type.value}_energy_min",
-                            f"training_{particle_type.value}_energy_max",
-                            f"training_{particle_type.value}_nsb_min",
-                            f"training_{particle_type.value}_nsb_max",
-                        ],
-                        dtype=[
-                            "S256",
-                            "S256",
-                            float,
-                            float,
-                            float,
-                            float,
-                            float,
-                            float,
-                        ],
-                        units=[None, None, "deg", "deg", "TeV", "TeV", "Hz", "Hz"],
-                    )
+                    training_table = training_index_table.default_table
 
                 training_table.add_row(
                     [
@@ -391,7 +351,7 @@ class CTLearnModelManager:
                 write_table_hdf5(
                     training_table,
                     self.model_index_file,
-                    path=f"{self.model_nickname}/training/{particle_type.value}",
+                    path=training_index_table.table_path,
                     append=True,
                     overwrite=True,
                     serialize_meta=True,
@@ -529,9 +489,8 @@ class CTLearnModelManager:
                 if transfer_learning_model_cpk is None
                 else f"--TrainCTLearnModel.model_type=LoadedModel --LoadedModel.load_model_from={transfer_learning_model_cpk} "
             )
-
         training_gamma_table = read_table_hdf5(
-            self.model_index_file, path=f"{self.model_nickname}/training/gamma_diffuse"
+            self.model_index_file, path=IndexTables(self, ParticleType.GAMMA_DIFFUSE).TRAINING.table_path
         )
         signal_patterns = ""
         for pattern in training_gamma_table["training_gamma_diffuse_patterns"]:
@@ -539,7 +498,7 @@ class CTLearnModelManager:
         background_patterns = ""
         if self.model_parameters_table["reco"][0] == "type":
             training_proton_table = read_table_hdf5(
-                self.model_index_file, path=f"{self.model_nickname}/training/proton"
+                self.model_index_file, path=IndexTables(self, ParticleType.PROTON).TRAINING.table_path
             )
             for pattern in training_proton_table["training_proton_patterns"]:
                 background_patterns += f'--pattern-background "{pattern}" '
@@ -715,8 +674,10 @@ class CTLearnModelManager:
         """
         from astropy.io.misc.hdf5 import read_table_hdf5, write_table_hdf5
 
+        
+
         model_table = read_table_hdf5(
-            self.model_index_file, path=f"{self.model_nickname}/parameters"
+            self.model_index_file, path=IndexTables(self).PARAMETERS.table_path
         )
         # model_index = np.where(model_table['model_nickname'] == self.model_nickname)[0][0]
         print(f"💾 Model {self.model_nickname} index update:")
@@ -733,7 +694,7 @@ class CTLearnModelManager:
         write_table_hdf5(
             model_table,
             self.model_index_file,
-            path=f"{self.model_nickname}/parameters",
+            path=IndexTables(self).PARAMETERS.table_path,
             append=True,
             overwrite=True,
             serialize_meta=True,
@@ -768,34 +729,18 @@ class CTLearnModelManager:
         testing_azimuth = testing_data_sample.azimuth
         testing_pattern = testing_data_sample.pattern
         particle_type = testing_data_sample.particle_type
+
+        testing_index_table = IndexTables(self, particle_type).TESTING
         try:
             testing_table = read_table_hdf5(
                 self.model_index_file,
-                path=f"{self.model_nickname}/testing/{particle_type.value}",
+                path=testing_index_table.table_path,
             )
         except:
-            testing_table = QTable(
-                names=[
-                    f"testing_{particle_type.value}_dirs",
-                    f"testing_{particle_type.value}_zenith_distances",
-                    f"testing_{particle_type.value}_azimuths",
-                    f"testing_{particle_type.value}_patterns",
-                ],
-                dtype=["S256", float, float, "S256"],
-                units=[None, "deg", "deg", None],
-            )
+            testing_table = testing_index_table.default_table
         # print(f"💾 Model {self.model_nickname} testing data update:")
         if len(testing_table) == 0:
-            testing_table = QTable(
-                names=[
-                    f"testing_{particle_type.value}_dirs",
-                    f"testing_{particle_type.value}_zenith_distances",
-                    f"testing_{particle_type.value}_azimuths",
-                    f"testing_{particle_type.value}_patterns",
-                ],
-                dtype=["S256", float, float, "S256"],
-                units=[None, "deg", "deg", None],
-            )
+            testing_table = testing_index_table.default_table
 
         match = np.where(
             (
@@ -819,7 +764,7 @@ class CTLearnModelManager:
         write_table_hdf5(
             testing_table,
             self.model_index_file,
-            path=f"{self.model_nickname}/testing/{particle_type.value}",
+            path=testing_index_table.table_path,
             append=True,
             overwrite=True,
             serialize_meta=True,
@@ -861,33 +806,19 @@ class CTLearnModelManager:
         testing_azimuth = testing_MC_DL2_data_sample.azimuth
         particle_type = testing_MC_DL2_data_sample.particle_type
 
+        dl2_mc_index_table = IndexTables(self, particle_type).DL2_MC
+
         try:
             DL2_gamma_table = read_table_hdf5(
                 self.model_index_file,
-                path=f"{self.model_nickname}/DL2/MC/{particle_type.value}",
+                path=dl2_mc_index_table.table_path,
             )
         except:
-            DL2_gamma_table = QTable(
-                names=[
-                    f"testing_DL2_{particle_type.value}_files",
-                    f"testing_DL2_{particle_type.value}_zenith_distances",
-                    f"testing_DL2_{particle_type.value}_azimuths",
-                ],
-                dtype=["S256", float, float],
-                units=[None, "deg", "deg"],
-            )
+            DL2_gamma_table = dl2_mc_index_table.default_table
 
         # print(f"💾 Model {self.model_nickname} DL2 data update:")
         if len(DL2_gamma_table) == 0:
-            DL2_gamma_table = QTable(
-                names=[
-                    f"testing_DL2_{particle_type.value}_files",
-                    f"testing_DL2_{particle_type.value}_zenith_distances",
-                    f"testing_DL2_{particle_type.value}_azimuths",
-                ],
-                dtype=["S256", float, float],
-                units=[None, "deg", "deg"],
-            )
+            DL2_gamma_table = dl2_mc_index_table.default_table
 
         match = np.where(
             (
@@ -916,7 +847,7 @@ class CTLearnModelManager:
         write_table_hdf5(
             DL2_gamma_table,
             self.model_index_file,
-            path=f"{self.model_nickname}/DL2/MC/{particle_type.value}",
+            path=dl2_mc_index_table.table_path,
             append=True,
             overwrite=True,
             serialize_meta=True,
@@ -943,9 +874,11 @@ class CTLearnModelManager:
         """
         from astropy.io.misc.hdf5 import read_table_hdf5, write_table_hdf5
 
+        dl2_mc_index_table = IndexTables(self, particle_type).DL2_MC
+
         DL2_table = read_table_hdf5(
             self.model_index_file,
-            path=f"{self.model_nickname}/DL2/MC/{particle_type.value}",
+            path=dl2_mc_index_table.table_path,
         )
         match = np.where(
             DL2_table[f"testing_DL2_{particle_type.value}_files"] == testing_DL2_file
@@ -955,7 +888,7 @@ class CTLearnModelManager:
         write_table_hdf5(
             DL2_table,
             self.model_index_file,
-            path=f"{self.model_nickname}/DL2/MC/{particle_type.value}",
+            path=dl2_mc_index_table.table_path,
             append=True,
             overwrite=True,
             serialize_meta=True,
@@ -996,22 +929,18 @@ class CTLearnModelManager:
         """
         from astropy.io.misc.hdf5 import read_table_hdf5, write_table_hdf5
 
+        dl2_data_index_table = IndexTables(self).DL2_DATA
+
         try:
             DL2_data_table = read_table_hdf5(
-                self.model_index_file, path=f"{self.model_nickname}/DL2/Data"
+                self.model_index_file, path=dl2_data_index_table.table_path
             )
         except:
-            DL2_data_table = QTable(
-                names=["DL2_files", "DL2_zenith_distances", "DL2_azimuths"],
-                dtype=["S256", float, float],
-            )
+            DL2_data_table = dl2_data_index_table.default_table
 
         print(f"💾 Model {self.model_nickname} DL2 data update:")
         if len(DL2_data_table) == 0:
-            DL2_data_table = QTable(
-                names=["DL2_files", "DL2_zenith_distances", "DL2_azimuths"],
-                dtype=["S256", float, float],
-            )
+            DL2_data_table = dl2_data_index_table.default_table
 
         if len(DL2_files) > 0:
             for i in range(len(DL2_files)):
@@ -1032,7 +961,7 @@ class CTLearnModelManager:
             write_table_hdf5(
                 DL2_data_table,
                 self.model_index_file,
-                path=f"{self.model_nickname}/DL2/Data",
+                path=dl2_data_index_table.table_path,
                 append=True,
                 overwrite=True,
                 serialize_meta=True,
@@ -1077,10 +1006,12 @@ class CTLearnModelManager:
         """
         from astropy.io.misc.hdf5 import read_table_hdf5, write_table_hdf5
 
+        dl2_mc_index_table = IndexTables(self, particle_type).DL2_MC
+
         print(f"💾 Model {self.model_nickname} DL2 merged data update:")
         DL2_table = read_table_hdf5(
             self.model_index_file,
-            path=f"{self.model_nickname}/DL2/MC/{particle_type.value}",
+            path=dl2_mc_index_table.table_path,
         )
         match = np.where(
             (
@@ -1100,7 +1031,7 @@ class CTLearnModelManager:
             write_table_hdf5(
                 DL2_table,
                 self.model_index_file,
-                path=f"{self.model_nickname}/DL2/MC/{particle_type.value}",
+                path=dl2_mc_index_table.table_path,
                 append=True,
                 overwrite=True,
                 serialize_meta=True,
@@ -1157,36 +1088,16 @@ class CTLearnModelManager:
         """
         from astropy.io.misc.hdf5 import read_table_hdf5, write_table_hdf5
 
+        irf_index_table = IndexTables(self).IRF
+
         try:
             IRF_table = read_table_hdf5(
-                self.model_index_file, path=f"{self.model_nickname}/IRF"
+                self.model_index_file, path=irf_index_table.table_path
             )
         except:
-            IRF_table = QTable(
-                names=[
-                    "config",
-                    "cuts_file",
-                    "irf_file",
-                    "benckmark_file",
-                    "zenith",
-                    "azimuth",
-                ],
-                dtype=["S256", "S256", "S256", "S256", float, float],
-                units=[None, None, None, None, "deg", "deg"],
-            )
+            IRF_table = irf_index_table.default_table
         if len(IRF_table) == 0:
-            IRF_table = QTable(
-                names=[
-                    "config",
-                    "cuts_file",
-                    "irf_file",
-                    "benckmark_file",
-                    "zenith",
-                    "azimuth",
-                ],
-                dtype=["S256", "S256", "S256", "S256", float, float],
-                units=[None, None, None, None, "deg", "deg"],
-            )
+            IRF_table = irf_index_table.default_table
 
         match = np.where(
             (IRF_table["config"] == config).any()
@@ -1205,7 +1116,7 @@ class CTLearnModelManager:
             write_table_hdf5(
                 IRF_table,
                 self.model_index_file,
-                path=f"{self.model_nickname}/IRF",
+                path=irf_index_table.table_path,
                 append=True,
                 overwrite=True,
                 serialize_meta=True,
@@ -1218,7 +1129,7 @@ class CTLearnModelManager:
             write_table_hdf5(
                 IRF_table,
                 self.model_index_file,
-                path=f"{self.model_nickname}/IRF",
+                path=irf_index_table.table_path,
                 append=True,
                 overwrite=True,
                 serialize_meta=True,
@@ -1275,7 +1186,7 @@ class CTLearnModelManager:
             return self.get_closest_IRF_data(average_zenith, average_azimuth, cuts)
 
         IRF_table = read_table_hdf5(
-            self.model_index_file, path=f"{self.model_nickname}/IRF"
+            self.model_index_file, path=IndexTables(self).IRF.table_path
         )
         target_irf_type = cuts.irf_type
         target_gamma_efficiency = cuts.efficiency_gammaness
@@ -1366,7 +1277,7 @@ class CTLearnModelManager:
         from astropy.io.misc.hdf5 import read_table_hdf5
 
         IRF_table = read_table_hdf5(
-            self.model_index_file, path=f"{self.model_nickname}/IRF"
+            self.model_index_file, path=IndexTables(self).IRF.table_path
         )
         if cuts is not None:
             target_irf_type = cuts.irf_type
@@ -1462,9 +1373,10 @@ class CTLearnModelManager:
 
         for particle_type in particle_types:
             try:
+                dl2_mc_index_table = IndexTables(self, particle_type).DL2_MC
                 DL2_table = read_table_hdf5(
                     self.model_index_file,
-                    path=f"{self.model_nickname}/DL2/MC/{particle_type.value}",
+                    path=dl2_mc_index_table.table_path,
                 )
                 match = np.where(
                     (
@@ -1552,12 +1464,13 @@ class CTLearnModelManager:
                 )
             else:
                 # Plot a portion of a circle between the azimuth range at the correct zenith
+                
                 theta = np.linspace(azimuth_min, azimuth_max, 100)
                 r = np.full_like(theta, zenith_min).to(u.deg)
                 ax.plot(theta, r, lw=3, zorder=0)
                 training_gamma_table = read_table_hdf5(
                     self.model_index_file,
-                    path=f"{self.model_nickname}/training/gamma_diffuse",
+                    path=IndexTables(self, ParticleType.GAMMA_DIFFUSE).TRAINING.table_path,
                 )
                 zeniths = training_gamma_table[
                     "training_gamma_diffuse_zenith_distances"
@@ -1642,10 +1555,10 @@ class CTLearnModelManager:
                     color=plt.rcParams["axes.prop_cycle"].by_key()["color"][1],
                     zorder=0,
                 )
-
+                ax.set_ylim(0, 60)
                 training_gamma_table = read_table_hdf5(
                     self.model_index_file,
-                    path=f"{self.model_nickname}/training/gamma_diffuse",
+                    path=IndexTables(self, ParticleType.GAMMA_DIFFUSE).TRAINING.table_path,
                 )
                 zeniths = training_gamma_table[
                     "training_gamma_diffuse_zenith_distances"
@@ -1664,7 +1577,7 @@ class CTLearnModelManager:
 
         try:
             testing_dl1_table = read_table_hdf5(
-                self.model_index_file, path=f"{self.model_nickname}/testing/gamma_point"
+                self.model_index_file, path=IndexTables(self, ParticleType.GAMMA_POINT).TESTING.table_path
             )
             zeniths = testing_dl1_table["testing_gamma_point_zenith_distances"]
             azimuths = testing_dl1_table["testing_gamma_point_azimuths"].to(u.rad)
@@ -1686,7 +1599,7 @@ class CTLearnModelManager:
 
         try:
             mc_dl2_table = read_table_hdf5(
-                self.model_index_file, path=f"{self.model_nickname}/DL2/MC/gamma_point"
+                self.model_index_file, path=IndexTables(self, ParticleType.GAMMA_POINT).DL2_MC.table_path
             )
             zeniths = mc_dl2_table["testing_DL2_gamma_point_zenith_distances"]
             azimuths = mc_dl2_table["testing_DL2_gamma_point_azimuths"].to(u.rad)
@@ -1758,7 +1671,7 @@ class CTLearnModelManager:
 
         fig, ax = plt.subplots(subplot_kw={"projection": "polar"})
         training_gamma_table = read_table_hdf5(
-            self.model_index_file, path=f"{self.model_nickname}/training/gamma_diffuse"
+            self.model_index_file, path=IndexTables(self, ParticleType.GAMMA_DIFFUSE).TRAINING.table_path
         )
         zeniths = training_gamma_table["training_gamma_diffuse_zenith_distances"]
         azimuths = training_gamma_table["training_gamma_diffuse_azimuths"].to(u.rad)
@@ -1783,7 +1696,7 @@ class CTLearnModelManager:
 
         if self.model_parameters_table["reco"][0] == "type":
             training_proton_table = read_table_hdf5(
-                self.model_index_file, path=f"{self.model_nickname}/training/proton"
+                self.model_index_file, path=IndexTables(self, ParticleType.PROTON).TRAINING.table_path
             )
             zeniths = training_proton_table["training_proton_zenith_distances"]
             azimuths = training_proton_table["training_proton_azimuths"].to(u.rad)
@@ -1883,7 +1796,7 @@ class ModelRangeOfValidity:
 
         training_gamma_table = read_table_hdf5(
             model_manager.model_index_file,
-            path=f"{model_manager.model_nickname}/training/gamma_diffuse",
+            path=IndexTables(self, ParticleType.GAMMA_DIFFUSE).TRAINING.table_path,
         )
         # training_proton_table = read_table_hdf5(model_manager.model_index_file, path=f'{model_manager.model_nickname}/training/proton')
 

--- a/src/ctlearn_manager/model_manager.py
+++ b/src/ctlearn_manager/model_manager.py
@@ -11,7 +11,7 @@ import astropy.units as u
 import numpy as np
 from astropy.table import QTable
 
-from ctlearn_manager.utils import (
+from ctlearn_manager.utils.utils import (
     ClusterConfiguration,
     CTLearnManagerStyle,
     Cuts,
@@ -21,8 +21,9 @@ from ctlearn_manager.utils import (
     get_irf_type_from_config,
     remove_row_from_table_utils,
     set_mpl_style,
-    IndexTables,
 )
+
+# from ctlearn_manager.utils.index_tables import IndexTables
 
 __all__ = [
     "CTLearnModelManager",
@@ -1930,3 +1931,130 @@ class ModelRangeOfValidity:
                 ):
                     return False
         return True
+
+
+class IndexTables:
+
+    def __call__(self, model_manager: CTLearnModelManager, particle_type: ParticleType=None):
+        self.model_manager = model_manager
+        self.particle_type = particle_type
+
+        if self.particle_type is not None:
+
+            self.DL2_MC = self.IndexTable(
+                QTable(
+                        names=[
+                            f"testing_DL2_{self.particle_type.value}_files",
+                            f"testing_DL2_{self.particle_type.value}_zenith_distances",
+                            f"testing_DL2_{self.particle_type.value}_azimuths",
+                            "merged",
+                        ],
+                        dtype=["S256", float, float, bool],
+                        units=[None, "deg", "deg", None],
+                    ),
+                f"{self.model_manager.model_nickname}/DL2/MC/{particle_type.value}"
+                )
+
+
+            self.TRAINING = self.IndexTable(
+                QTable(
+                        names=[
+                            f"training_{particle_type.value}_dir",
+                            f"training_{particle_type.value}_patterns",
+                            f"training_{particle_type.value}_zenith_distances",
+                            f"training_{particle_type.value}_azimuths",
+                            f"training_{particle_type.value}_energy_min",
+                            f"training_{particle_type.value}_energy_max",
+                            f"training_{particle_type.value}_nsb_min",
+                            f"training_{particle_type.value}_nsb_max",
+                        ],
+                        dtype=[
+                            "S256",
+                            "S256",
+                            float,
+                            float,
+                            float,
+                            float,
+                            float,
+                            float,
+                        ],
+                        units=[None, None, "deg", "deg", "TeV", "TeV", "Hz", "Hz"],
+                    ),
+                f"{self.model_manager.model_nickname}/training/{particle_type.value}")
+            
+            self.TESTING = self.IndexTable(
+                QTable(
+                    names=[
+                        f"testing_{particle_type.value}_dirs",
+                        f"testing_{particle_type.value}_zenith_distances",
+                        f"testing_{particle_type.value}_azimuths",
+                        f"testing_{particle_type.value}_patterns",
+                    ],
+                    dtype=["S256", float, float, "S256"],
+                    units=[None, "deg", "deg", None],
+            ),
+                f"{self.model_manager.model_nickname}/testing/{particle_type.value}",
+            )
+
+
+        self.PARAMETERS = self.IndexTable(
+            QTable(
+                names=[
+                    "model_nickname",
+                    "model_dir",
+                    "reco",
+                    "channels",
+                    "telescope_names",
+                    "telescope_ids",
+                    "notes",
+                    "max_training_epochs",
+                    "min_telescopes",
+                    "stereo",
+                ],
+                dtype=[
+                    "S256",
+                    "S256",
+                    "S256",
+                    "S256",
+                    "S256",
+                    "S256",
+                    "S256",
+                    int,
+                    int,
+                    bool,
+                ],
+            ),
+            f"{self.model_manager.model_nickname}/parameters"
+        )
+
+
+        self.IRF = self.IndexTable(
+            QTable(
+                names=[
+                    "config",
+                    "cuts_file",
+                    "irf_file",
+                    "benckmark_file",
+                    "zenith",
+                    "azimuth",
+                ],
+                dtype=["S256", "S256", "S256", "S256", float, float],
+                units=[None, None, None, None, "deg", "deg"],
+            ),
+            f"{self.model_manager.model_nickname}/IRF"
+        )
+
+
+        self.DL2_DATA = self.IndexTable(
+            QTable(
+                names=["DL2_files", "DL2_zenith_distances", "DL2_azimuths"],
+                dtype=["S256", float, float],
+            ),
+            f"{self.model_manager.model_nickname}/DL2/Data"
+        )
+
+
+    class IndexTable:
+        def __init__(self, default_table: QTable, table_path: str):
+            self.default_table = default_table
+            self.table_path = table_path

--- a/src/ctlearn_manager/tri_model.py
+++ b/src/ctlearn_manager/tri_model.py
@@ -980,7 +980,7 @@ class CTLearnTriModelManager:
         import os
 
         files = self.direction_model.get_DL2_MC_files(
-            zenith, azimuth, particle_types=[particle_type]
+            zenith, azimuth, merged=False, particle_types=[particle_type]
         )[particle_type.value]
         if len(files) > 1:
             print(
@@ -1446,11 +1446,11 @@ class CTLearnTriModelManager:
 
         if pointlike:
             gamma_files = self.direction_model.get_DL2_MC_files(
-                zenith, azimuth, particle_types=[ParticleType.GAMMA_POINT]
+                zenith, azimuth, particle_types=[ParticleType.GAMMA_POINT], merged=True
             )[ParticleType.GAMMA_POINT.value]
         else:
             gamma_files = self.direction_model.get_DL2_MC_files(
-                zenith, azimuth, particle_types=[ParticleType.GAMMA_DIFFUSE]
+                zenith, azimuth, particle_types=[ParticleType.GAMMA_DIFFUSE], merged=True
             )[ParticleType.GAMMA_DIFFUSE.value]
         if len(gamma_files) > 1:
             raise ValueError(
@@ -1459,7 +1459,7 @@ class CTLearnTriModelManager:
         gamma_file = gamma_files[0]
         if electrons:
             electrons_files = self.direction_model.get_DL2_MC_files(
-                zenith, azimuth, particle_types=[ParticleType.ELECTRON]
+                zenith, azimuth, particle_types=[ParticleType.ELECTRON], merged=True
             )[ParticleType.ELECTRON.value]
             if len(electrons_files) > 1:
                 raise ValueError(
@@ -1469,7 +1469,7 @@ class CTLearnTriModelManager:
 
         if protons:
             proton_files = self.direction_model.get_DL2_MC_files(
-                zenith, azimuth, particle_types=[ParticleType.PROTON]
+                zenith, azimuth, particle_types=[ParticleType.PROTON], merged=True
             )[ParticleType.PROTON.value]
             if len(proton_files) > 1:
                 raise ValueError(

--- a/src/ctlearn_manager/tri_model.py
+++ b/src/ctlearn_manager/tri_model.py
@@ -654,7 +654,7 @@ class CTLearnTriModelManager:
 --no-dl1-images --no-true-images --output {output_file} \
 --DLImageReader.mode=stereo --PredictCTLearnModel.stack_telescope_images=True --DLImageReader.min_telescopes={self.min_telescopes} \
 --PredictCTLearnModel.overwrite_tables=True -v {channels_string} {force_dl1_lookup_string} \
-{config_string}"
+{config_string} --overwrite={overwrite}"
             else:
                 # cmd = f"ctlearn-predict-mono --input_url {input_file} --type_model={type_model_dir}/ctlearn_model.cpk --energy_model={energy_model_dir}/ctlearn_model.cpk --direction_model={direction_model_dir}/ctlearn_model.cpk --no-dl1-images --no-true-images --output {output_file} --overwrite -v {channels_string}"
                 cmd = f"ctlearn-predict-mono-model --input_url {input_file} \
@@ -665,7 +665,7 @@ class CTLearnTriModelManager:
 --no-dl1-images --no-true-images --output {output_file} \
 --use-HDF5Merger{dl2_subarray_string} \
 --PredictCTLearnModel.overwrite_tables=True -v {channels_string} {force_dl1_lookup_string} \
-{config_string}"
+{config_string} --overwrite={overwrite}"
 
             if self.cluster_configuration.use_cluster:
                 # sbatch_file = write_sbatch_script(cluster_configuration.cluster, Path(input_file).stem, cmd, config_dir, env_name=cluster_configuration.python_env, account=cluster_configuration.account)

--- a/src/ctlearn_manager/tri_model.py
+++ b/src/ctlearn_manager/tri_model.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import astropy.units as u
 import numpy as np
+from tqdm import tqdm
 
 from .io.io import load_DL2_data_MC, load_true_shower_parameters
 from .model_manager import CTLearnModelManager, DataSample
@@ -260,7 +261,7 @@ class CTLearnTriModelManager:
         testing samples. After updating, it retrieves the available testing
         directions.
         """
-        for model in [self.direction_model, self.energy_model, self.type_model]:
+        for model in tqdm([self.direction_model, self.energy_model, self.type_model], desc="Setting testing data"):
             for data_sample in testing_samples:
                 model.update_model_manager_testing_data(data_sample)
         self.get_available_testing_directions()
@@ -654,7 +655,7 @@ class CTLearnTriModelManager:
 --no-dl1-images --no-true-images --output {output_file} \
 --DLImageReader.mode=stereo --PredictCTLearnModel.stack_telescope_images=True --DLImageReader.min_telescopes={self.min_telescopes} \
 --PredictCTLearnModel.overwrite_tables=True -v {channels_string} {force_dl1_lookup_string} \
-{config_string} --overwrite={overwrite}"
+{config_string}"# --overwrite={overwrite}"
             else:
                 # cmd = f"ctlearn-predict-mono --input_url {input_file} --type_model={type_model_dir}/ctlearn_model.cpk --energy_model={energy_model_dir}/ctlearn_model.cpk --direction_model={direction_model_dir}/ctlearn_model.cpk --no-dl1-images --no-true-images --output {output_file} --overwrite -v {channels_string}"
                 cmd = f"ctlearn-predict-mono-model --input_url {input_file} \
@@ -665,7 +666,7 @@ class CTLearnTriModelManager:
 --no-dl1-images --no-true-images --output {output_file} \
 --use-HDF5Merger{dl2_subarray_string} \
 --PredictCTLearnModel.overwrite_tables=True -v {channels_string} {force_dl1_lookup_string} \
-{config_string} --overwrite={overwrite}"
+{config_string}"# --overwrite={overwrite}"
 
             if self.cluster_configuration.use_cluster:
                 # sbatch_file = write_sbatch_script(cluster_configuration.cluster, Path(input_file).stem, cmd, config_dir, env_name=cluster_configuration.python_env, account=cluster_configuration.account)
@@ -1012,9 +1013,21 @@ class CTLearnTriModelManager:
                 print(
                     f"Error: Failed to merge gamma files for zenith {zenith} and azimuth {azimuth}"
                 )
-        else:
+        elif len(files) == 1:
+            for model in [
+                    self.direction_model,
+                    self.energy_model,
+                    self.type_model,
+                ]:
+                    model.update_merged_DL2_MC_files(
+                        zenith, azimuth, files[0], particle_type
+                    )
             print(
-                f"✅ There already is a single {particle_type.value} file for zenith {zenith} and azimuth {azimuth}"
+                f"✅ There is a single {particle_type.value} file for zenith {zenith} and azimuth {azimuth}, a new row has been added as 'merged' in the model index, as a duplicate of the single file row. To add more files, simply run testing and merge again."
+            )
+        else:
+            raise ValueError(
+                f"No DL2 MC files found for zenith {zenith} and azimuth {azimuth} for particle type {particle_type.value}"
             )
 
     @u.quantity_input(zenith=u.deg, azimuth=u.deg)

--- a/src/ctlearn_manager/utils/__init__.py
+++ b/src/ctlearn_manager/utils/__init__.py
@@ -1,1 +1,2 @@
 from .utils import *
+from .index_tables import *

--- a/src/ctlearn_manager/utils/index_tables.py
+++ b/src/ctlearn_manager/utils/index_tables.py
@@ -12,15 +12,17 @@ class IndexTables():
         self.particle_type = particle_type
 
         if self.particle_type is not None:
+
             self.DL2_MC = self.IndexTable(
                 QTable(
                         names=[
                             f"testing_DL2_{self.particle_type.value}_files",
                             f"testing_DL2_{self.particle_type.value}_zenith_distances",
                             f"testing_DL2_{self.particle_type.value}_azimuths",
+                            "merged",
                         ],
-                        dtype=["S256", float, float],
-                        units=[None, "deg", "deg"],
+                        dtype=["S256", float, float, bool],
+                        units=[None, "deg", "deg", None],
                     ),
                 f"{self.model_manager.model_nickname}/DL2/MC/{particle_type.value}"
                 )
@@ -114,7 +116,7 @@ class IndexTables():
             f"{self.model_manager.model_nickname}/IRF"
         )
 
-        
+
         self.DL2_DATA = self.IndexTable(
             QTable(
                 names=["DL2_files", "DL2_zenith_distances", "DL2_azimuths"],

--- a/src/ctlearn_manager/utils/index_tables.py
+++ b/src/ctlearn_manager/utils/index_tables.py
@@ -1,132 +1,132 @@
-from astropy.table import QTable
-from .utils import ParticleType
-from ..model_manager import CTLearnModelManager
+# from astropy.table import QTable
+# from .utils import ParticleType
+# from ..model_manager import CTLearnModelManager
 
-__all__ = [
-    "IndexTables",]
+# __all__ = [
+#     "IndexTables",]
 
-class IndexTables():
+# class IndexTables():
 
-    def __call__(self, model_manager: CTLearnModelManager, particle_type: ParticleType=None):
-        self.model_manager = model_manager
-        self.particle_type = particle_type
+#     def __call__(self, model_manager: CTLearnModelManager, particle_type: ParticleType=None):
+#         self.model_manager = model_manager
+#         self.particle_type = particle_type
 
-        if self.particle_type is not None:
+#         if self.particle_type is not None:
 
-            self.DL2_MC = self.IndexTable(
-                QTable(
-                        names=[
-                            f"testing_DL2_{self.particle_type.value}_files",
-                            f"testing_DL2_{self.particle_type.value}_zenith_distances",
-                            f"testing_DL2_{self.particle_type.value}_azimuths",
-                            "merged",
-                        ],
-                        dtype=["S256", float, float, bool],
-                        units=[None, "deg", "deg", None],
-                    ),
-                f"{self.model_manager.model_nickname}/DL2/MC/{particle_type.value}"
-                )
+#             self.DL2_MC = self.IndexTable(
+#                 QTable(
+#                         names=[
+#                             f"testing_DL2_{self.particle_type.value}_files",
+#                             f"testing_DL2_{self.particle_type.value}_zenith_distances",
+#                             f"testing_DL2_{self.particle_type.value}_azimuths",
+#                             "merged",
+#                         ],
+#                         dtype=["S256", float, float, bool],
+#                         units=[None, "deg", "deg", None],
+#                     ),
+#                 f"{self.model_manager.model_nickname}/DL2/MC/{particle_type.value}"
+#                 )
 
 
-            self.TRAINING = self.IndexTable(
-                QTable(
-                        names=[
-                            f"training_{particle_type.value}_dir",
-                            f"training_{particle_type.value}_patterns",
-                            f"training_{particle_type.value}_zenith_distances",
-                            f"training_{particle_type.value}_azimuths",
-                            f"training_{particle_type.value}_energy_min",
-                            f"training_{particle_type.value}_energy_max",
-                            f"training_{particle_type.value}_nsb_min",
-                            f"training_{particle_type.value}_nsb_max",
-                        ],
-                        dtype=[
-                            "S256",
-                            "S256",
-                            float,
-                            float,
-                            float,
-                            float,
-                            float,
-                            float,
-                        ],
-                        units=[None, None, "deg", "deg", "TeV", "TeV", "Hz", "Hz"],
-                    ),
-                f"{self.model_manager.model_nickname}/training/{particle_type.value}")
+#             self.TRAINING = self.IndexTable(
+#                 QTable(
+#                         names=[
+#                             f"training_{particle_type.value}_dir",
+#                             f"training_{particle_type.value}_patterns",
+#                             f"training_{particle_type.value}_zenith_distances",
+#                             f"training_{particle_type.value}_azimuths",
+#                             f"training_{particle_type.value}_energy_min",
+#                             f"training_{particle_type.value}_energy_max",
+#                             f"training_{particle_type.value}_nsb_min",
+#                             f"training_{particle_type.value}_nsb_max",
+#                         ],
+#                         dtype=[
+#                             "S256",
+#                             "S256",
+#                             float,
+#                             float,
+#                             float,
+#                             float,
+#                             float,
+#                             float,
+#                         ],
+#                         units=[None, None, "deg", "deg", "TeV", "TeV", "Hz", "Hz"],
+#                     ),
+#                 f"{self.model_manager.model_nickname}/training/{particle_type.value}")
             
-            self.TESTING = self.IndexTable(
-                QTable(
-                    names=[
-                        f"testing_{particle_type.value}_dirs",
-                        f"testing_{particle_type.value}_zenith_distances",
-                        f"testing_{particle_type.value}_azimuths",
-                        f"testing_{particle_type.value}_patterns",
-                    ],
-                    dtype=["S256", float, float, "S256"],
-                    units=[None, "deg", "deg", None],
-            ),
-                f"{self.model_manager.model_nickname}/testing/{particle_type.value}",
-            )
+#             self.TESTING = self.IndexTable(
+#                 QTable(
+#                     names=[
+#                         f"testing_{particle_type.value}_dirs",
+#                         f"testing_{particle_type.value}_zenith_distances",
+#                         f"testing_{particle_type.value}_azimuths",
+#                         f"testing_{particle_type.value}_patterns",
+#                     ],
+#                     dtype=["S256", float, float, "S256"],
+#                     units=[None, "deg", "deg", None],
+#             ),
+#                 f"{self.model_manager.model_nickname}/testing/{particle_type.value}",
+#             )
 
 
-        self.PARAMETERS = self.IndexTable(
-            QTable(
-                names=[
-                    "model_nickname",
-                    "model_dir",
-                    "reco",
-                    "channels",
-                    "telescope_names",
-                    "telescope_ids",
-                    "notes",
-                    "max_training_epochs",
-                    "min_telescopes",
-                    "stereo",
-                ],
-                dtype=[
-                    "S256",
-                    "S256",
-                    "S256",
-                    "S256",
-                    "S256",
-                    "S256",
-                    "S256",
-                    int,
-                    int,
-                    bool,
-                ],
-            ),
-            f"{self.model_manager.model_nickname}/parameters"
-        )
+#         self.PARAMETERS = self.IndexTable(
+#             QTable(
+#                 names=[
+#                     "model_nickname",
+#                     "model_dir",
+#                     "reco",
+#                     "channels",
+#                     "telescope_names",
+#                     "telescope_ids",
+#                     "notes",
+#                     "max_training_epochs",
+#                     "min_telescopes",
+#                     "stereo",
+#                 ],
+#                 dtype=[
+#                     "S256",
+#                     "S256",
+#                     "S256",
+#                     "S256",
+#                     "S256",
+#                     "S256",
+#                     "S256",
+#                     int,
+#                     int,
+#                     bool,
+#                 ],
+#             ),
+#             f"{self.model_manager.model_nickname}/parameters"
+#         )
 
 
-        self.IRF = self.IndexTable(
-            QTable(
-                names=[
-                    "config",
-                    "cuts_file",
-                    "irf_file",
-                    "benckmark_file",
-                    "zenith",
-                    "azimuth",
-                ],
-                dtype=["S256", "S256", "S256", "S256", float, float],
-                units=[None, None, None, None, "deg", "deg"],
-            ),
-            f"{self.model_manager.model_nickname}/IRF"
-        )
+#         self.IRF = self.IndexTable(
+#             QTable(
+#                 names=[
+#                     "config",
+#                     "cuts_file",
+#                     "irf_file",
+#                     "benckmark_file",
+#                     "zenith",
+#                     "azimuth",
+#                 ],
+#                 dtype=["S256", "S256", "S256", "S256", float, float],
+#                 units=[None, None, None, None, "deg", "deg"],
+#             ),
+#             f"{self.model_manager.model_nickname}/IRF"
+#         )
 
 
-        self.DL2_DATA = self.IndexTable(
-            QTable(
-                names=["DL2_files", "DL2_zenith_distances", "DL2_azimuths"],
-                dtype=["S256", float, float],
-            ),
-            f"{self.model_manager.model_nickname}/DL2/Data"
-        )
+#         self.DL2_DATA = self.IndexTable(
+#             QTable(
+#                 names=["DL2_files", "DL2_zenith_distances", "DL2_azimuths"],
+#                 dtype=["S256", float, float],
+#             ),
+#             f"{self.model_manager.model_nickname}/DL2/Data"
+#         )
 
 
-    class IndexTable:
-        def __init__(self, default_table: QTable, table_path: str):
-            self.default_table = default_table
-            self.table_path = table_path
+#     class IndexTable:
+#         def __init__(self, default_table: QTable, table_path: str):
+#             self.default_table = default_table
+#             self.table_path = table_path

--- a/src/ctlearn_manager/utils/index_tables.py
+++ b/src/ctlearn_manager/utils/index_tables.py
@@ -1,0 +1,130 @@
+from astropy.table import QTable
+from .utils import ParticleType
+from ..model_manager import CTLearnModelManager
+
+__all__ = [
+    "IndexTables",]
+
+class IndexTables():
+
+    def __call__(self, model_manager: CTLearnModelManager, particle_type: ParticleType=None):
+        self.model_manager = model_manager
+        self.particle_type = particle_type
+
+        if self.particle_type is not None:
+            self.DL2_MC = self.IndexTable(
+                QTable(
+                        names=[
+                            f"testing_DL2_{self.particle_type.value}_files",
+                            f"testing_DL2_{self.particle_type.value}_zenith_distances",
+                            f"testing_DL2_{self.particle_type.value}_azimuths",
+                        ],
+                        dtype=["S256", float, float],
+                        units=[None, "deg", "deg"],
+                    ),
+                f"{self.model_manager.model_nickname}/DL2/MC/{particle_type.value}"
+                )
+
+
+            self.TRAINING = self.IndexTable(
+                QTable(
+                        names=[
+                            f"training_{particle_type.value}_dir",
+                            f"training_{particle_type.value}_patterns",
+                            f"training_{particle_type.value}_zenith_distances",
+                            f"training_{particle_type.value}_azimuths",
+                            f"training_{particle_type.value}_energy_min",
+                            f"training_{particle_type.value}_energy_max",
+                            f"training_{particle_type.value}_nsb_min",
+                            f"training_{particle_type.value}_nsb_max",
+                        ],
+                        dtype=[
+                            "S256",
+                            "S256",
+                            float,
+                            float,
+                            float,
+                            float,
+                            float,
+                            float,
+                        ],
+                        units=[None, None, "deg", "deg", "TeV", "TeV", "Hz", "Hz"],
+                    ),
+                f"{self.model_manager.model_nickname}/training/{particle_type.value}")
+            
+            self.TESTING = self.IndexTable(
+                QTable(
+                    names=[
+                        f"testing_{particle_type.value}_dirs",
+                        f"testing_{particle_type.value}_zenith_distances",
+                        f"testing_{particle_type.value}_azimuths",
+                        f"testing_{particle_type.value}_patterns",
+                    ],
+                    dtype=["S256", float, float, "S256"],
+                    units=[None, "deg", "deg", None],
+            ),
+                f"{self.model_manager.model_nickname}/testing/{particle_type.value}",
+            )
+
+
+        self.PARAMETERS = self.IndexTable(
+            QTable(
+                names=[
+                    "model_nickname",
+                    "model_dir",
+                    "reco",
+                    "channels",
+                    "telescope_names",
+                    "telescope_ids",
+                    "notes",
+                    "max_training_epochs",
+                    "min_telescopes",
+                    "stereo",
+                ],
+                dtype=[
+                    "S256",
+                    "S256",
+                    "S256",
+                    "S256",
+                    "S256",
+                    "S256",
+                    "S256",
+                    int,
+                    int,
+                    bool,
+                ],
+            ),
+            f"{self.model_manager.model_nickname}/parameters"
+        )
+
+
+        self.IRF = self.IndexTable(
+            QTable(
+                names=[
+                    "config",
+                    "cuts_file",
+                    "irf_file",
+                    "benckmark_file",
+                    "zenith",
+                    "azimuth",
+                ],
+                dtype=["S256", "S256", "S256", "S256", float, float],
+                units=[None, None, None, None, "deg", "deg"],
+            ),
+            f"{self.model_manager.model_nickname}/IRF"
+        )
+
+        
+        self.DL2_DATA = self.IndexTable(
+            QTable(
+                names=["DL2_files", "DL2_zenith_distances", "DL2_azimuths"],
+                dtype=["S256", float, float],
+            ),
+            f"{self.model_manager.model_nickname}/DL2/Data"
+        )
+
+
+    class IndexTable:
+        def __init__(self, default_table: QTable, table_path: str):
+            self.default_table = default_table
+            self.table_path = table_path

--- a/src/ctlearn_manager/utils/utils.py
+++ b/src/ctlearn_manager/utils/utils.py
@@ -245,9 +245,18 @@ srun {command}
         )
     return sbatch_predict_data_configs[cluster]
 
+def get_user_confirmation(prompt: str):
+    user_confirmation = input(
+        prompt
+    )
+    if user_confirmation.lower() != "yes":
+        raise ValueError("Operation cancelled by the user.")
+    
 
 def remove_model_from_index(model_nickname, MODEL_INDEX_FILE):
     import h5py
+    get_user_confirmation(f"Are you sure you want to remove the model '{model_nickname}' from the index? (yes/no): ")
+    
 
     with h5py.File(MODEL_INDEX_FILE, "a") as f:
         try:
@@ -259,6 +268,10 @@ def remove_model_from_index(model_nickname, MODEL_INDEX_FILE):
 
 def remove_row_from_table_utils(index_file, table_path: str, row_index: int):
     from astropy.io.misc.hdf5 import read_table_hdf5, write_table_hdf5
+
+    get_user_confirmation(
+        f"Are you sure you want to remove row {row_index} from the table at path '{table_path}' ? (yes/no): "
+    )
 
     try:
         table = read_table_hdf5(index_file, path=table_path)
@@ -297,6 +310,10 @@ def remove_table_from_h5(file_path: str, table_path: str):
     :param table_path: Path to the table within the HDF5 file.
     :type table_path: str
     """
+
+    get_user_confirmation(
+        f"Are you sure you want to remove the table at path '{table_path}' from the file '{file_path}'? (yes/no): "
+    )
 
     try:
         with h5py.File(file_path, "a") as h5_file:
@@ -671,7 +688,7 @@ class DataSample:
                 raise ValueError(f"Unknown particle ID: {particle_id}")
 
         print(
-            f"DataSample : Particle type: {self.particle_type.value} (ZD, Az): ({self.zenith_distance}, {self.azimuth})"
+            f"\t -> {self.particle_type.value} @ ({self.zenith_distance}, {self.azimuth})"
         )
 
 
@@ -901,3 +918,5 @@ def get_irf_type_from_config(config):
             raise ValueError(
                 f"Unknown optimization algorithm: {optimization_algorithm}"
             )
+                
+        


### PR DESCRIPTION
before :
When merging MD DL2 files (required for IRF production) the manager deletes the rows in the index table, and create a unique row with the merged fil instead.

after :
The MC DL2 table has a new columns containing a flag indicating if the file is a merged one or not. When merging, the original files (rows with 'merged'=False) are kept, and a new row is created with the merged file and corresponding flag.
If there is only one file per direction, the user needs to merge it (it will nor really merge it but only create a new row with corresponding 'merged'=True flag, so that it can be found.
New files can be added for the same direction, and merging will remerge all non-merged files corresponding to that direction. There can be only one merged file per direction, so the row will be overwritter no matter what.